### PR TITLE
Allow token param to be passed for token activations

### DIFF
--- a/lib/amco/cas/scope.rb
+++ b/lib/amco/cas/scope.rb
@@ -8,7 +8,7 @@ module Amco
         before_action :filter_amco_id, :require_user
 
         def cas_params
-          params.permit(:logoutRequest, :ticket, :renew, :id, :format, :commit, :utf8)
+          params.permit(:logoutRequest, :ticket, :renew, :id, :format, :commit, :utf8, :token)
         end
 
         private


### PR DESCRIPTION
Allows token param to be passed to amco id to allow Token students flow 