### PR TITLE
Pass params cleanly to avoid issues

### DIFF
--- a/lib/amco/cas/filter.rb
+++ b/lib/amco/cas/filter.rb
@@ -6,13 +6,11 @@ module Amco
       class << self
         def filter(controller)
            raise ArgumentError.new('controller param missing') if controller.nil?
-          controller&.params = controller&.cas_params
           super(controller)
         end
 
         def logout(controller, service = nil)
           raise ArgumentError.new('controller param missing') if controller.nil?
-          controller&.params = controller&.cas_params
           super(controller, service)
         end
       end

--- a/lib/amco/cas/scope.rb
+++ b/lib/amco/cas/scope.rb
@@ -7,10 +7,6 @@ module Amco
 
         before_action :filter_amco_id, :require_user
 
-        def cas_params
-          params.permit(:logoutRequest, :ticket, :renew, :id, :format, :commit, :utf8, :token)
-        end
-
         private
 
         def current_user


### PR DESCRIPTION
This was causing all url params to not being permitted into the app that implemented CAS so i figured it'd be better to allow params as they are and let the apps be the owner of the params and responsible of filtering

This was causing issues with Pundit `permitted_params` too